### PR TITLE
allow disabling exit

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "Binding": "0.0.0.0:8080",
     "ScriptFolder": ".\\scripts\\",
     "CommandsEnabled": true,
-    "ScriptsEnabled": true
+    "ScriptsEnabled": true,
+    "ExitEnabled": true
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func init() {
 	config.SetDefault("Binding", "0.0.0.0:8080")
 	config.SetDefault("ScriptFolder", ".\\scripts\\")
 	config.SetDefault("CommandsEnabled", true)
+	config.SetDefault("ExitEnabled", true)
 }
 
 func main() {
@@ -37,7 +38,10 @@ func main() {
 
 	mx := mux.NewRouter()
 	mx.HandleFunc("/", IndexHandler)
-	mx.HandleFunc("/exit", ExitHandler)
+
+	if config.GetBool("ExitEnabled") {
+		mx.HandleFunc("/exit", ExitHandler)
+	}
 
 	if config.GetBool("ScriptsEnabled") {
 		mx.HandleFunc("/scripts/{name:\\S+}", RunScript)


### PR DESCRIPTION
I don't want anyone who can access the API to be able to shut down the API. This adds a configuration option to disable that.
